### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -8,4 +8,4 @@
 
 composer_version=2.5.8
 
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.